### PR TITLE
Create experience API endpoints

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/back-end/src/main/java/resumebuilder/back_end/api/controller/ResumeController.java
+++ b/back-end/src/main/java/resumebuilder/back_end/api/controller/ResumeController.java
@@ -1,14 +1,95 @@
 package resumebuilder.back_end.api.controller;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import resumebuilder.back_end.api.model.Experience;
+import resumebuilder.back_end.service.ResumeService;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 @RestController
 public class ResumeController {
+
+    private ResumeService resumeService;
+
+    @Autowired
+    public ResumeController(ResumeService resumeService) {
+        this.resumeService = resumeService;
+    }
+
     @GetMapping("/")
     public ResponseEntity<String> getMethodTest() {
         System.out.println("is in / path");
         return ResponseEntity.ok("the api is working");
     }
+
+    @GetMapping("/experiences")
+    public ResponseEntity<List<Experience>> getExperiences() {
+        return new ResponseEntity<>(resumeService.getExperiences(), HttpStatus.OK);
+    }
+
+    @GetMapping("/experiences/{id}")
+    public ResponseEntity<Experience> getExperience(@PathVariable("id") int id) {
+        Optional<Experience> experience = resumeService.getExperience(id);
+
+        if (experience.isPresent()) {
+            return new ResponseEntity<>(experience.get(), HttpStatus.OK);
+        } else {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+    }
+
+    @PostMapping("/experiences")
+    public ResponseEntity<Experience> createExperience(@RequestBody Experience experience) {
+        resumeService.createExperience(experience);
+        return new ResponseEntity<>(experience, HttpStatus.CREATED);
+    }
+
+    @PutMapping(path = "/experiences/{id}")
+    public ResponseEntity<Experience> updateExperience(
+            @PathVariable("id") int id, @RequestBody Experience updatedExperience
+    ) {
+        Optional<Experience> existingExperienceOpt = resumeService.getExperience(id);
+
+        if (!existingExperienceOpt.isPresent()) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+
+        Experience updated = resumeService.updateExperience(id, updatedExperience);
+
+        return new ResponseEntity<>(updated, HttpStatus.OK);
+    }
+
+    @PatchMapping(path = "/experiences/{id}")
+    public ResponseEntity<Experience> patchExperience(
+            @PathVariable("id") int id, @RequestBody Map<String, Object> updates
+    ) {
+        // Fetch the existing experience
+        Optional<Experience> existingExperienceOpt = resumeService.getExperience(id);
+
+        if (!existingExperienceOpt.isPresent()) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+
+        // Partially update the experience
+        Experience updatedExperience = resumeService.partialUpdateExperience(id, updates);
+
+        return new ResponseEntity<>(updatedExperience, HttpStatus.OK);
+    }
+
+    @DeleteMapping(path = "/experiences/{id}")
+    public ResponseEntity<Experience> deleteExperience(@PathVariable("id") int id) {
+        Optional<Experience> deletedExperience = resumeService.deleteExperience(id);
+
+        if(deletedExperience.isPresent()) {
+            return new ResponseEntity<>(deletedExperience.get(), HttpStatus.OK);
+        } else {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+    }
+
 }

--- a/back-end/src/main/java/resumebuilder/back_end/api/model/CustomDate.java
+++ b/back-end/src/main/java/resumebuilder/back_end/api/model/CustomDate.java
@@ -1,0 +1,27 @@
+package resumebuilder.back_end.api.model;
+
+public class CustomDate {
+    private int month;
+    private int year;
+
+    public CustomDate(int month, int year) {
+        this.month = month;
+        this.year = year;
+    }
+
+    public int getMonth() {
+        return month;
+    }
+
+    public void setMonth(int month) {
+        this.month = month;
+    }
+
+    public int getYear() {
+        return year;
+    }
+
+    public void setYear(int year) {
+        this.year = year;
+    }
+}

--- a/back-end/src/main/java/resumebuilder/back_end/api/model/Experience.java
+++ b/back-end/src/main/java/resumebuilder/back_end/api/model/Experience.java
@@ -1,0 +1,87 @@
+package resumebuilder.back_end.api.model;
+
+public class Experience {
+    private int id;
+    private String company;
+    private String location;
+    private String position;
+    private CustomDate start_date;
+    private CustomDate end_date;
+    private String description;
+    private boolean visible;
+
+    public Experience(int id, String company, String location, String position, CustomDate start_date, CustomDate end_date, String description, boolean visible) {
+        this.id = id;
+        this.company = company;
+        this.location = location;
+        this.position = position;
+        this.start_date = start_date;
+        this.end_date = end_date;
+        this.description = description;
+        this.visible = visible;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getCompany() {
+        return company;
+    }
+
+    public void setCompany(String company) {
+        this.company = company;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
+
+    public String getPosition() {
+        return position;
+    }
+
+    public void setPosition(String position) {
+        this.position = position;
+    }
+
+    public CustomDate getStart_date() {
+        return start_date;
+    }
+
+    public void setStart_date(CustomDate start_date) {
+        this.start_date = start_date;
+    }
+
+    public CustomDate getEnd_date() {
+        return end_date;
+    }
+
+    public void setEnd_date(CustomDate end_date) {
+        this.end_date = end_date;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public boolean isVisible() {
+        return visible;
+    }
+
+    public void setVisible(boolean visible) {
+        this.visible = visible;
+    }
+}

--- a/back-end/src/main/java/resumebuilder/back_end/api/model/Resume.java
+++ b/back-end/src/main/java/resumebuilder/back_end/api/model/Resume.java
@@ -1,5 +1,7 @@
 package resumebuilder.back_end.api.model;
 
+import java.util.ArrayList;
+
 public class Resume {
     /*
      * Complete this model as you guys work on the endpoints.
@@ -9,7 +11,18 @@ public class Resume {
      * Also, changing these to interfaces might be good later.
      */
     private Education education;
+    
+    private ArrayList<Experience> experience;
 
-    public Resume() {
+    public Resume(ArrayList<Experience> experience) {
+        this.experience = experience;
+    }
+
+    public ArrayList<Experience> getExperience() {
+        return experience;
+    }
+
+    public void setExperience(ArrayList<Experience> experience) {
+        this.experience = experience;
     }
 }

--- a/back-end/src/main/java/resumebuilder/back_end/service/ResumeService.java
+++ b/back-end/src/main/java/resumebuilder/back_end/service/ResumeService.java
@@ -1,0 +1,184 @@
+package resumebuilder.back_end.service;
+
+import org.springframework.stereotype.Service;
+import resumebuilder.back_end.api.model.CustomDate;
+import resumebuilder.back_end.api.model.Experience;
+import resumebuilder.back_end.api.model.GraduationDate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+public class ResumeService {
+
+    private List<Experience> experienceList;
+    private int nextId = 1;
+    private boolean visible = true;
+
+    public ResumeService() {
+        experienceList = new ArrayList<Experience>();
+
+        experienceList.add(new Experience(
+                nextId++,
+                "The Ohio State University",
+                "Columbus, Ohio",
+                "Resident Advisor",
+                new CustomDate(8, 2018),
+                null,
+                "Ensured safety and served as a resource for 65+ residents\nFacilitated programs to foster the growth and development of undergraduate students\nAddressed and resolved issues to ensure a quality living experience for all residents in the residence hall",
+                true
+        ));
+
+        experienceList.add(new Experience(
+                nextId++,
+                "L Brands",
+                "Columbus, Ohio",
+                "Operations Management Intern",
+                new CustomDate(5, 2019),
+                new CustomDate(8, 2019),
+                "Developed 40+ new standardized operating procedures to improve efficiency, productivity, and employee morale\nWorked with a team of 10 distribution managers to expand Bath and Body Works operations to a secondary campus",
+                true
+        ));
+
+        experienceList.add(new Experience(
+                nextId++,
+                "The Ohio State University Wexner Medical Center",
+                "Columbus, Ohio",
+                "Supply Chain Intern",
+                new CustomDate(5, 2018),
+                new CustomDate(8, 2018),
+                "Collaborated with the purchasing department to develop metrics for tracking department performance\nResolved several hundred pricing discrepancies\nFormulated standard operating procedures for future interns",
+                true
+        ));
+
+        experienceList.add(new Experience(
+                nextId++,
+                "Buckeye Undergraduate Consulting Club",
+                "Columbus, Ohio",
+                "VP of Marketing and Communications",
+                new CustomDate(1, 2017),
+                null,
+                "Conducted market research on blockchain technology feasibility for wire transactions\nDeveloped analytical skills through Power BI and Tableau workshops\nCompeted in three case competitions",
+                false
+        ));
+
+        experienceList.add(new Experience(
+                nextId++,
+                "Phi Chi Theta Professional Business Fraternity",
+                "Columbus, Ohio",
+                "Professional Development Chair",
+                new CustomDate(2, 2018),
+                null,
+                "Created individualized professional development experiences for new members\nDeveloped and executed workshops to enrich pledges' understanding of brotherhood, professionalism, and philanthropy",
+                false
+        ));
+
+        experienceList.add(new Experience(
+                nextId++,
+                "Fisher Emerging Consultants",
+                "Columbus, Ohio",
+                "Member",
+                new CustomDate(2, 2019),
+                new CustomDate(4, 2019),
+                "Participated in a consulting career readiness program focusing on problem solving, professionalism, and networking",
+                false
+        ));
+    }
+
+    public boolean exists(int id) {
+        for(Experience experience: experienceList) {
+            if(id == experience.getId()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public List<Experience> getExperiences() {
+        return experienceList;
+    }
+
+    public Optional<Experience> getExperience(int id) {
+        Optional<Experience> optional = Optional.empty();
+        for (Experience experience: experienceList) {
+            if(id == experience.getId()) {
+                optional = Optional.of(experience);
+                return optional;
+            }
+        }
+        return optional;
+    }
+
+    public void createExperience(Experience experience) {
+        experience.setId(nextId++);
+        experienceList.add(experience);
+    }
+
+    public Experience updateExperience(int id, Experience updatedExperience) {
+        Experience experienceToUpdate = getExperience(id).orElseThrow(() -> new IllegalArgumentException("Experience not found"));
+
+        experienceToUpdate.setCompany(updatedExperience.getCompany());
+        experienceToUpdate.setLocation(updatedExperience.getLocation());
+        experienceToUpdate.setPosition(updatedExperience.getPosition());
+        experienceToUpdate.setStart_date(updatedExperience.getStart_date());
+        experienceToUpdate.setEnd_date(updatedExperience.getEnd_date());
+        experienceToUpdate.setDescription(updatedExperience.getDescription());
+        experienceToUpdate.setVisible(updatedExperience.isVisible());
+
+        return experienceToUpdate;
+    }
+
+    public Experience partialUpdateExperience(int id, Map<String, Object> updates) {
+        Experience experienceToPatch = getExperience(id).orElseThrow(() -> new IllegalArgumentException("Experience not found"));
+
+        // Loop through the updates and apply them if the field exists
+        updates.forEach((key, value) -> {
+            switch (key) {
+                case "company":
+                    experienceToPatch.setCompany((String) value);
+                    break;
+                case "location":
+                    experienceToPatch.setLocation((String) value);
+                    break;
+                case "position":
+                    experienceToPatch.setPosition((String) value);
+                    break;
+                case "start_date":
+                    Map<String, Integer> startDate = (Map<String, Integer>) value;
+                    experienceToPatch.setStart_date(new CustomDate(startDate.get("month"), startDate.get("year")));
+                    break;
+                case "end_date":
+                    if (value != null) {
+                        Map<String, Integer> endDate = (Map<String, Integer>) value;
+                        experienceToPatch.setEnd_date(new CustomDate(endDate.get("month"), endDate.get("year")));
+                    } else {
+                        experienceToPatch.setEnd_date(null);
+                    }
+                    break;
+                case "description":
+                    experienceToPatch.setDescription((String) value);
+                    break;
+                case "visible":
+                    experienceToPatch.setVisible((Boolean) value);
+                    break;
+                default:
+                    throw new IllegalArgumentException("Invalid field: " + key);
+            }
+        });
+
+        return experienceToPatch;
+    }
+
+
+    public Optional<Experience> deleteExperience(int id) {
+        for (Experience experience: experienceList) {
+            if (experience.getId() == id) {
+                experienceList.remove(experience);
+                return Optional.of(experience);
+            }
+        }
+        return Optional.empty();
+    }
+}


### PR DESCRIPTION
This pull request adds the get (one/all), post, put, patch, and delete endpoints for the experiences section of the resume. 

- made the service layer package similar to how the controller looks
- created new class CustomDate for experience start and end dates